### PR TITLE
[feat] 크리에이터 마이페이지 정산 기능 api 연동 완료

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -62,6 +62,8 @@ export const ENDPOINTS = {
     qrStatus: 'ACTIVE' | 'INACTIVE'
   ) =>
     `${BASE_URL}/api/creators/creator-center/projects/${projectId}/makers/orderId/${orderId}/status/${qrStatus}`,
+  CREATOR_PROJECT_SETTLEMENT: (projectId: number) =>
+    `${BASE_URL}/api/creators/creator-center/projects/${projectId}/settlement`,
 
   //어드민
 

--- a/src/components/MyPage/project-result/ProjectResultPage.tsx
+++ b/src/components/MyPage/project-result/ProjectResultPage.tsx
@@ -28,7 +28,7 @@ const ProjectResultPage = () => {
       case 'makers':
         return <MakersTab projectId={numericProjectId} />;
       case 'settlement':
-        return <SettlementTab />;
+        return <SettlementTab projectId={numericProjectId} />;
       default:
         return null;
     }

--- a/src/components/MyPage/project-result/tabs/PaymentStatusCard.tsx
+++ b/src/components/MyPage/project-result/tabs/PaymentStatusCard.tsx
@@ -27,14 +27,8 @@ export const PaymentStatusCard = ({ status }: Props) => {
 
   return (
     <div className="self-stretch p-4 bg-[#F3E8FF] rounded-xl flex items-center">
-      {icon && (
-        <div className={`w-5 h-5 ${color}`}>
-          {icon}
-        </div>
-      )}
-      <div className="pl-3 text-base font-semiBoldFont leading-6">
-        {text}
-      </div>
+      {icon && <div className={`w-5 h-5 ${color}`}>{icon}</div>}
+      <div className="pl-3 text-base font-semiBoldFont leading-6">{text}</div>
     </div>
   );
 };

--- a/src/components/MyPage/project-result/tabs/SettlementTab.tsx
+++ b/src/components/MyPage/project-result/tabs/SettlementTab.tsx
@@ -1,58 +1,86 @@
-import { Lock } from 'lucide-react';
-import { PaymentStatusCard } from './PaymentStatusCard';
+import api from '../../../../api/axiosInstance';
+import ENDPOINTS from '../../../../api/endpoints';
+import type {
+  Settlement,
+  SettlementResponse,
+} from '../../../../types/settlement';
+import { useEffect, useState } from 'react';
 
-{/*interface SettlementTabProps {
-  projectId?: string;
-}*/}
+interface SettlementTabProps {
+  projectId?: number;
+}
 
-const SettlementTab = ({/*{ projectId }: SettlementTabProps*/}) => {
-  const paymentStatus: 'PENDING' | 'PROCESSING' | 'DONE' = 'DONE';
+const SettlementTab = ({ projectId }: SettlementTabProps) => {
+  const [settlement, setSettlement] = useState<Settlement | null>(null);
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    const fetchSettlement = async () => {
+      try {
+        const response = await api.get<SettlementResponse>(
+          ENDPOINTS.CREATOR_PROJECT_SETTLEMENT(projectId)
+        );
+
+        if (!response.data.success) {
+          console.error(response.data.error);
+          return;
+        }
+
+        setSettlement(response.data.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchSettlement();
+  }, [projectId]);
 
   return (
-    <div className="w-[768px] p-8 bg-white rounded-2xl border border-white80 flex flex-col gap-6">
+    <section className="w-[768px] p-8 bg-white rounded-2xl border border-white80 flex flex-col gap-6">
       {/* 제목 */}
-      <div className="text-[#1F2937] text-xl font-boldFont leading-7">정산</div>
+      <header>
+        <h2 className="text-[#1F2937] text-xl font-boldFont leading-7">정산</h2>
+      </header>
 
-      <div className="w-[702px] flex flex-col gap-6">
+      <dl className="w-[702px] flex flex-col gap-6">
         {/* 총 모금액 */}
         <div className="flex flex-col gap-2">
-          <div className="text-[#374151] text-sm font-mediumFont leading-5">
+          <dt className="text-[#374151] text-sm font-mediumFont leading-5">
             총 모금액
-          </div>
-          <div className="h-14 px-4 bg-white rounded-xl border border-white60 flex items-center">
-            <div className="text-black80 text-base font-mainFont leading-6">
-              지역 문화예술 축제를 통해 커뮤니티를 연결합니다.
-            </div>
-          </div>
+          </dt>
+          <dd className="h-14 px-4 bg-white rounded-xl border border-white60 flex items-center">
+            <span className="text-black80 text-base font-mainFont leading-6">
+              {settlement?.totalAmount?.toLocaleString() ?? '0'}원
+            </span>
+          </dd>
         </div>
 
         {/* 수수료 */}
         <div className="flex flex-col gap-2">
-          <div className="text-[#374151] text-sm font-mediumFont leading-5">
+          <dt className="text-[#374151] text-sm font-mediumFont leading-5">
             수수료
-          </div>
-          <div className="h-14 px-4 bg-white rounded-xl border border-white60 flex items-center">
-            <div className="text-black80 text-base font-mainFont leading-6">
-              #태그 입력 (Enter)
-            </div>
-          </div>
+          </dt>
+          <dd className="h-14 px-4 bg-white rounded-xl border border-white60 flex items-center">
+            <span className="text-black40 text-base font-mainFont leading-6">
+              {settlement?.feeAmount?.toLocaleString() ?? '0'}원
+            </span>
+          </dd>
         </div>
 
-        {/* 지급 상태 */}
-        <div className="self-stretch pt-6 border-t border-white60 flex flex-col gap-4 text-[#854D0E]">
-          <div className="self-stretch p-4 bg-[#F3E8FF] rounded-xl flex items-start">
-            <div className="w-5 h-5 text-[#CA8A04]">
-              <Lock size={20} />
-            </div>
-            <div className="pl-3 text-base font-semiBoldFont leading-6">
-              지급액
-            </div>
-          </div>
-
-          <PaymentStatusCard status={paymentStatus} />
+        {/* 정산 예정액 */}
+        <div className="flex flex-col gap-2">
+          <dt className="text-[#374151] text-sm font-mediumFont leading-5">
+            정산 예정액
+          </dt>
+          <dd className="h-14 px-4 bg-black rounded-xl flex items-center">
+            <span className="text-[#F2F1F1] text-base font-mainFont leading-6">
+              {settlement?.payoutAmount?.toLocaleString() ?? '0'}원
+            </span>
+          </dd>
         </div>
-      </div>
-    </div>
+      </dl>
+    </section>
   );
 };
 

--- a/src/types/settlement.ts
+++ b/src/types/settlement.ts
@@ -1,0 +1,9 @@
+import type { ApiResponse } from '../api/auth';
+
+export type Settlement = {
+  totalAmount: number;
+  feeAmount: number;
+  payoutAmount: number;
+};
+
+export type SettlementResponse = ApiResponse<Settlement>;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #59 

## 📝작업 내용

- 크리에이터의 마이페이지에서 프로젝트고유 ID에 맞는 정산 api를 불러와 적용하였습니다.
- 정산 페이지의 ui를 피그마에 맞게 수정하였습니다.

### 스크린샷 (선택)

<img width="1022" height="549" alt="image" src="https://github.com/user-attachments/assets/99b5ec4b-e847-40cb-a0ac-d97db62d3c5e" />


## 💬리뷰 요구사항(선택)
